### PR TITLE
Added 10Gbps interface rate

### DIFF
--- a/collector/monitor_collector.go
+++ b/collector/monitor_collector.go
@@ -107,6 +107,8 @@ func (c *monitorCollector) valueForProp(name, value string) int {
 				return 100
 			case v == "1Gbps":
 				return 1000
+			case v == "10Gbps":
+				return 10000
 			}
 			return 0
 		}(value)


### PR DESCRIPTION
Under current code for rate detection, 10Gbps interfaces return a value of "0". This addition adds a value of "10000" to be returned when 10Gbps interface is detected.